### PR TITLE
Improve redis routing repository stability

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
@@ -23,12 +23,16 @@ import org.springframework.cloud.gateway.support.NotFoundException;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.ReactiveValueOperations;
 import org.springframework.stereotype.Repository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Dennis Menge
  */
 @Repository
 public class RedisRouteDefinitionRepository implements RouteDefinitionRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisRouteDefinitionRepository.class);
 
 	/**
 	 * Key prefix for RouteDefinition queries to redis.
@@ -48,7 +52,13 @@ public class RedisRouteDefinitionRepository implements RouteDefinitionRepository
 	@Override
 	public Flux<RouteDefinition> getRouteDefinitions() {
 		return reactiveRedisTemplate.keys(createKey("*"))
-				.flatMap(key -> reactiveRedisTemplate.opsForValue().get(key));
+				.flatMap(key -> reactiveRedisTemplate.opsForValue().get(key))
+                .onErrorResume(throwable -> {
+                    if (log.isErrorEnabled()) {
+                        log.error("get routes from redis error cause : {}", throwable.toString(), throwable);
+                    }
+                    return Flux.empty();
+                });;
 	}
 
 	@Override

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
@@ -53,11 +53,10 @@ public class RedisRouteDefinitionRepository implements RouteDefinitionRepository
 	public Flux<RouteDefinition> getRouteDefinitions() {
 		return reactiveRedisTemplate.keys(createKey("*"))
 				.flatMap(key -> reactiveRedisTemplate.opsForValue().get(key))
-                .onErrorResume(throwable -> {
+				.onErrorContinue((throwable, routeDefinition) -> {
                     if (log.isErrorEnabled()) {
                         log.error("get routes from redis error cause : {}", throwable.toString(), throwable);
                     }
-                    return Flux.empty();
                 });
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
@@ -58,7 +58,7 @@ public class RedisRouteDefinitionRepository implements RouteDefinitionRepository
                         log.error("get routes from redis error cause : {}", throwable.toString(), throwable);
                     }
                     return Flux.empty();
-                });;
+                });
 	}
 
 	@Override


### PR DESCRIPTION
Failure of loading routes will cause gateway crash.
Adding exception handler to avoid this situation.